### PR TITLE
Use deepcopy to help with diffing and updating records

### DIFF
--- a/dynamic_rest_client/record.py
+++ b/dynamic_rest_client/record.py
@@ -1,6 +1,6 @@
 from .utils import unpack
 from .exceptions import DoesNotExist
-
+import copy
 
 class DRESTRecord(object):
 
@@ -83,7 +83,7 @@ class DRESTRecord(object):
         for key, value in data.items():
             setattr(self, key, value)
 
-        self._clean = self._get_data()
+        self._clean = copy.deepcopy(self._get_data())
         self.id = data.get('_meta', {}).get('id', data.get('id', None))
 
     def _serialize(self, data):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 NAME = 'dynamic-rest-client'
 DESCRIPTION = 'Python client for dynamic-rest with minimal dependencies'
 URL = 'http://github.com/AltSchool/dynamic-rest-client'
-VERSION = '0.1.1'
+VERSION = '0.1.2'
 SCRIPTS = []
 
 setup(


### PR DESCRIPTION
In scenarios where a record's field is itself an object with its own nested hierarchy, not using deepcopy results in `_get_data()` and `_clean` having no diff and referencing that same nested object. As a result no patching of changes to the nested data being made. This fixes that by making `_clean` a deepcopy of data when data is loaded, so that changes can be detected within nested objects. 