### PR TITLE
Fix authentication logic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 NAME = 'dynamic-rest-client'
 DESCRIPTION = 'Python client for dynamic-rest with minimal dependencies'
 URL = 'http://github.com/AltSchool/dynamic-rest-client'
-VERSION = '0.1.3'
+VERSION = '0.1.4'
 SCRIPTS = []
 
 setup(


### PR DESCRIPTION
1) There was no way to query a client object to see if it is authenticated -> added `authenticated` property

2) The `_authenticated` bool field was true when credentials were provided but without checking if they were valid -> now `_authenticated` is true when a login was successful (or when no credentials were provided; I'm assuming this is there for mocking/testing purposes

3) The `_authenticate` method had some dead code -> removed