### PR TITLE
Docs and makefile cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,24 +11,11 @@ Use `make lint` to check your code for style violations.
 We use the `flake8` linter to enforce PEP8 code style. 
 For additional details, see our [Python style guide](https://github.com/AltSchool/Python).
 
-## Documentation
-
-Use `make docs` to generate the automated documentation for the project.
-
-We recommend documenting all public modules, classes, and methods, but generating the documentation is not required.
-
 ## Tests
 
 Use `make test` to lint and run all unit tests (runs in a few seconds).
-Use `make tox` to run all unit tests against all supported combinations of Python, Django, and Django REST Framework (can take several minutes).
 
 We recommend linting regularly, testing with every commit, and running tests against all combinations before submitting a pull request.
-
-## Benchmarks
-
-Use `make benchmark` to benchmark your changes against the latest version of Django REST Framework (can take several minutes).
-
-We recommend running this before submitting a pull request. Doing so will create a [benchmarks.html](benchmarks.html) file in the repository root directory.
 
 # Submission
 
@@ -44,5 +31,5 @@ Before releasing:
 
 - Check/update the version in `dynamic_rest/constants.py`
 - Commit changes and tag the commit with the version, prefixed by "v"
-- Run `make pypi_upload_test` to upload a new version to PyPiTest. Check the contents at https://pypitest.python.org/pypi/dynamic-rest
-- Run `make pypi_upload` to upload a new version to PyPi. Check the contents at https://pypi.python.org/pypi/dynamic-rest
+- Run `make pypi_upload_test` to upload a new version to PyPiTest. Check the contents at https://test.pypi.org/project/dynamic-rest-client
+- Run `make pypi_upload` to upload a new version to PyPi. Check the contents at https://pypi.python.org/pypi/dynamic-rest-client

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,6 @@ endef
 
 .PHONY: docs
 
-pypi_register_test: install
-	$(call header,"Registering with PyPi - test")
-	@. $(INSTALL_DIR)/bin/activate; python setup.py register -r pypitest
-
-pypi_register: install
-	$(call header,"Registering with PyPi")
-	@. $(INSTALL_DIR)/bin/activate; python setup.py register -r pypi
-
 pypi_upload_test: install
 	$(call header,"Uploading new version to PyPi - test")
 	@. $(INSTALL_DIR)/bin/activate; python setup.py sdist upload -r pypitest


### PR DESCRIPTION
Updating Contributing.md documentation
    
    Apparently this documentation was copied from dynamic-rest and included
    some sections (Documentation & Benchmarking) which were not relevant to
    this project and were removed. Additionally, I updated the URLs of where
    to check that pypi was uploaded because the testing location had changed
    and both ULS were pointing to the dynamic-rest packages instead of the
    dynamic-rest-client ones


Removing Makefile rules for deprecated register operations
    
    When run, these rules return with:
    
    Server response (410): Project pre-registration is no longer required or
    supported, so continue directly to uploading files.
