### PR TITLE
client auth fixup

### DIFF
--- a/dynamic_rest_client/client.py
+++ b/dynamic_rest_client/client.py
@@ -157,7 +157,6 @@ class DRESTClient(object):
                 self._use_token(token)
             if cookie:
                 self._use_cookie(cookie)
-            self._authenticate(raise_exception=False)
 
     @property
     def authenticated(self):
@@ -175,6 +174,7 @@ class DRESTClient(object):
 
     def _use_token(self, value):
         self._token = value
+        self._authenticated = bool(value)
         self._client.headers.update({
             'Authorization': '%s %s' % (
                 self._token_type, self._token if value else ''
@@ -183,6 +183,7 @@ class DRESTClient(object):
 
     def _use_cookie(self, value):
         self._cookie = value
+        self._authenticated = bool(value)
         self._client.headers.update({
             'Cookie': '%s=%s' % (self._cookie_name, value)
         })
@@ -211,10 +212,7 @@ class DRESTClient(object):
         if raise_exception:
             response.raise_for_status()
 
-        cookie = response.cookies.get(self._cookie_name)
-        if cookie:
-            self._use_cookie(cookie)
-            self._authenticated = True
+        self._use_cookie(response.cookies.get(self._cookie_name))
 
     def _authenticate(self, raise_exception=True):
         if not self._authenticated:


### PR DESCRIPTION
Reverts most changes introduced by 6d510df16680e4be40dba49d563d921681254d9d

The changes in 6d510df16680e4be40dba49d563d921681254d9d made
authentication semantics even worse, by breaking the sessionid init path
which allowed us to use a sessionid instead of username:pass each time
we wanted to authenticate a client.