### PR TITLE
test against updated dj2.2 minor versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ shell: install
 # Install/update dependencies
 # Runs whenever the requirements.txt file changes
 $(INSTALL_DIR): $(INSTALL_DIR)/bin/activate
-$(INSTALL_DIR)/bin/activate: requirements.txt install_requires.txt dependency_links.txt
+$(INSTALL_DIR)/bin/activate: requirements.txt install_requires.txt
 	$(call header,"Updating dependencies")
 	@test -d $(INSTALL_DIR) || virtualenv $(INSTALL_DIR)
 	@$(INSTALL_DIR)/bin/pip install -q --upgrade pip==18.1 setuptools flake8==2.4.0
-	@$(INSTALL_DIR)/bin/pip install --process-dependency-links -Ur requirements.txt
+	@$(INSTALL_DIR)/bin/pip install -Ur requirements.txt
 	@touch $(INSTALL_DIR)/bin/activate
 
 # Removes build files in working directory

--- a/install_requires.txt
+++ b/install_requires.txt
@@ -1,3 +1,3 @@
-inflection==0.3.1
+inflection>=0.3.1
 requests
 six

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pytest-django==3.1.2
 pytest-sugar==0.9.1
 pytest==3.6.4
 dynamic_rest>=1.6.0
-Django>=1.8,<=2.2
+Django>=1.8,<3.0
 django-debug-toolbar==1.7

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,12 @@ from setuptools import find_packages, setup
 NAME = 'dynamic-rest-client'
 DESCRIPTION = 'Python client for dynamic-rest with minimal dependencies'
 URL = 'http://github.com/AltSchool/dynamic-rest-client'
-VERSION = '0.1.6'
+VERSION = '0.1.7'
 SCRIPTS = []
 
 setup(
     description=DESCRIPTION,
     include_package_data=True,
-    dependency_links=open('dependency_links.txt').readlines(),
     install_requires=open('install_requires.txt').readlines(),
     long_description=open('README.rst').read(),
     name=NAME,

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ envlist = py27, py36
 setenv =
     PYTHONDONTWRITEBYTECODE=1
     DJANGO_SETTINGS_MODULE=tests.settings
-    PIP_PROCESS_DEPENDENCY_LINKS=1
 
 deps =
     -rrequirements.txt


### PR DESCRIPTION
 * don't restrict requirements to 2.2
 * Allow for `inflection` >= 0.3.1 since dynamic rest requires it going forward
 * Drop dependency_links checking (deprecated in modern versions of pip and the file was blank anyway)

```
savinay@Savinays-MacBook-Pro:~/alt/dynamic-rest-client$ tox
GLOB sdist-make: /Users/savinay/alt/dynamic-rest-client/setup.py
py27 inst-nodeps: /Users/savinay/alt/dynamic-rest-client/.tox/.tmp/package/1/dynamic-rest-client-0.1.7.zip
py27 installed: DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support,atomicwrites==1.4.0,attrs==19.3.0,certifi==2020.4.5.1,chardet==3.0.4,coverage==5.1,Django==1.11.29,django-debug-toolbar==1.7,djangorestframework==3.9.4,dynamic-rest==1.9.6,dynamic-rest-client==0.1.7,flake8==2.4.0,funcsigs==1.0.2,idna==2.9,inflection==0.3.1,mccabe==0.3.1,more-itertools==5.0.0,pep8==1.5.7,pluggy==0.7.1,py==1.8.1,pyflakes==0.8.1,pytest==3.6.4,pytest-cov==2.6.0,pytest-django==3.1.2,pytest-sugar==0.9.1,pytz==2020.1,requests==2.23.0,six==1.15.0,sqlparse==0.3.1,termcolor==1.1.0,urllib3==1.25.9
py27 run-test-pre: PYTHONHASHSEED='1068955448'
py27 run-test: commands[0] | py.test -s tests
Test session starts (platform: darwin, Python 2.7.14, pytest 3.6.4, pytest-sugar 0.9.1)
Django settings: tests.settings (from environment variable)
rootdir: /Users/savinay/alt/dynamic-rest-client, inifile: tox.ini
plugins: sugar-0.9.1, django-3.1.2, cov-2.6.0

 tests/test_client.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                                                                    95% █████████▌
 tests/test_deepcopy.py ✓                                                                                                                                                                                                                                                   100% ██████████

Results (1.68s):
      20 passed
py36 inst-nodeps: /Users/savinay/alt/dynamic-rest-client/.tox/.tmp/package/1/dynamic-rest-client-0.1.7.zip
py36 installed: atomicwrites==1.4.0,attrs==19.3.0,certifi==2020.4.5.1,chardet==3.0.4,coverage==5.1,Django==2.2.12,django-debug-toolbar==1.7,djangorestframework==3.10.3,dynamic-rest==1.9.6,dynamic-rest-client==0.1.7,flake8==2.4.0,idna==2.9,inflection==0.4.0,mccabe==0.3.1,more-itertools==8.3.0,pep8==1.5.7,pluggy==0.7.1,py==1.8.1,pyflakes==0.8.1,pytest==3.6.4,pytest-cov==2.6.0,pytest-django==3.1.2,pytest-sugar==0.9.1,pytz==2020.1,requests==2.23.0,six==1.15.0,sqlparse==0.3.1,termcolor==1.1.0,urllib3==1.25.9
py36 run-test-pre: PYTHONHASHSEED='1068955448'
py36 run-test: commands[0] | py.test -s tests
Test session starts (platform: darwin, Python 3.6.6, pytest 3.6.4, pytest-sugar 0.9.1)
Django settings: tests.settings (from environment variable)
rootdir: /Users/savinay/alt/dynamic-rest-client, inifile: tox.ini
plugins: sugar-0.9.1, django-3.1.2, cov-2.6.0

 tests/test_client.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                                                                                                                                                                                                                                    95% █████████▌
 tests/test_deepcopy.py ✓                                                                                                                                                                                                                                                   100% ██████████

Results (1.55s):
      20 passed
_________________________________________________________________________________________________________________________________________ summary _________________________________________________________________________________________________________________________________________
  py27: commands succeeded
  py36: commands succeeded
  congratulations :)
```