### PR TITLE
Tox tests on python 3.7 & 3.8 #ALTOS-24050

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,7 @@ lint: clean_working_directory
 format: clean_working_directory
 	$(call header,"Auto-formatting code")
 	@find $(APP_NAME) -type f -name '*.py' | xargs $(INSTALL_DIR)/bin/flake8 | sed -E 's/^([^:]*\.py).*/\1/g' | uniq | xargs autopep8 --experimental -a --in-place
+
+tox:
+	pip install -U tox==3.24.5; \
+	tox --develop

--- a/dynamic_rest_client/query.py
+++ b/dynamic_rest_client/query.py
@@ -167,7 +167,7 @@ class DRESTQuery(object):
                 if self._page == self._pages:
                     # end of results
                     self._reset()
-                    raise StopIteration()
+                    return
                 self._get_page(params)
 
             yield self._data[self._index]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 NAME = 'dynamic-rest-client'
 DESCRIPTION = 'Python client for dynamic-rest with minimal dependencies'
 URL = 'http://github.com/AltSchool/dynamic-rest-client'
-VERSION = '0.1.7'
+VERSION = '0.1.8'
 SCRIPTS = []
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 addopts=--tb=short
 
 [tox]
-envlist = py27, py36
+envlist = py36, py37, py38, py39
 
 [testenv]
 setenv =


### PR DESCRIPTION
Run tox tests on python 3.7 and 3.8, with one code change.
I was having issues trying to install 3.9 so just keeping it to these for now.
Backend update: AltSchool/vishnu-backend#7217